### PR TITLE
Fix to lookup functions in frametable.cpp - very strange iterator was re...

### DIFF
--- a/frametable.cpp
+++ b/frametable.cpp
@@ -122,50 +122,28 @@ FrameTable::FrameTableEntry FrameTable::_table[] = {
 int FrameTable::_tableSize = sizeof(_table) / sizeof(FrameTableEntry);
 
 const char* FrameTable::frameDescription(const String &textFID) {
-	int a = 0, b = _tableSize, i;
-
-	while (a < b) {
-		i = (a + b) / 2;
+	for (uint i = 1; i < _tableSize; i++) {
 		if (textFID == _table[i].id)
 			return _table[i].description;
-		else if (textFID < _table[i].id)
-			b = i - 1;
-		else
-			a = i + 1;
 	}
-
+	cerr << "   no table entry found for field " << textFID 
+		<< ".  returning " << _table[0].description << endl;
 	return _table[0].description;
 }
 
 ID3v2FrameID FrameTable::frameID(const String &textFID) {
-	int a = 0, b = _tableSize, i;
-
-	while (a < b) {
-		i = (a + b) / 2;
+	for (uint i = 1; i < _tableSize; i++) {
 		if (textFID == _table[i].id)
 			return _table[i].fid;
-		else if (textFID < _table[i].id)
-			b = i - 1;
-		else
-			a = i + 1;
 	}
-
 	return _table[0].fid;
 }
 
 const char* FrameTable::textFrameID(ID3v2FrameID frameID) {
-	int a = 0, b = _tableSize, i;
-
-	while (a <= b) {
-		i = (a + b) / 2;
+	for (uint i = 1; i < _tableSize; i++) {
 		if (frameID == _table[i].fid)
 			return _table[i].id;
-		else if (frameID < _table[i].fid)
-			b = i - 1;
-		else
-			a = i + 1;
 	}
-
 	return _table[0].id;
 }
 


### PR DESCRIPTION
Greetings

This is my first pull request.  I just started using id3ted; it's the only command-line tool that I found that had some support for the full range of id3v2 tags.  Thanks!

However, I discovered that it was not able to read back some of the tags that it wrote, specifically the TBPM (beats-per-minute tag).  It could write it, but not read it back.

I traced the issue back to the iterators in frametable.cpp.  It's a very strange iterator which does not iterate in sequential order, nor does it iterate through all table entries.  This commit simplifies and reduces the iterators as well as fixing the bug.

I can provide a test script as well.

Thanks!

Bryant Hansen
