### PR TITLE
Only output valid ISO-639-2 language codes, issue #9

### DIFF
--- a/mp3file.cpp
+++ b/mp3file.cpp
@@ -483,10 +483,15 @@ void MP3File::listID3v2Tag(bool withDesc) const {
 				if (lyrics != NULL) {
 					const char *text = lyrics->text().toCString(USE_UTF8);
 					const char *indent = "    ";
+					TagLib::ByteVector lang = lyrics->language();
+					bool showLanguage = lang.size() == 3;
 
-					cout << "[" << lyrics->description().toCString(USE_UTF8)
-					     << "](" << lyrics->language().data()
-					     << "):\n" << indent;
+					cout << "[" << lyrics->description().toCString(USE_UTF8) << "]";
+					if (showLanguage)
+						cout << "(" << lang[0] << lang[1] << lang[2];
+					else
+						cout << "(XXX";
+					cout << "):\n" << indent;
 					while (*text != '\0') {
 						if (*text == (char) 10 || *text == (char) 13)
 							cout << "\n" << indent;


### PR DESCRIPTION
This just adds a simple length check to ensure validity of the language code (but does not validate the code itself). The standard says it should always be ISO-639-2 which are always 3 characters long. The printing of `lyrics->language().data()` is not bounded, therefore unpredictable, and can easily corrupt a terminal due to junk bytes at the end of that point in memory. If we are lucky we get junk bytes starting with `\x00` but this is not the case most of time as I showed in issue #9.

This does not fully solve #9 completely as invalid data can still be printed (if encoded in the file by hand), but if tags are done properly with id3ted itself, e.g.:

``` bash
id3ted --USLT "$(< lyrics):description text:eng" the.mp3
```

`eng` should always be printed without extra bytes from the `TByteVector::data()` method. This should fix most issues regarding outputting fully compliant UTF-8 with the `--list` argument and other features.
